### PR TITLE
Correct the portfolio url link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This is my portfolio created with React.
 
 Check this URL:
-[https://komi1230.github.io/portfolio](https://komi1230.github.io/portfolio)
+[https://komi1230.github.io](https://komi1230.github.io)


### PR DESCRIPTION
## 👏 issue
- the url ``https://komi1230.github.io/portfolio`` in README.md is 404 not found

## ⛏ Details of Changes
- changed that into ``https://komi1230.github.io``

## 📸 Screenshots
Before the correction
![image](https://user-images.githubusercontent.com/44029144/79355285-67a6a900-7f78-11ea-8275-a5ae86a28134.png)
